### PR TITLE
Set personal Width/Height wrapper outter

### DIFF
--- a/jquery.fixedTblHdrLftCol.js
+++ b/jquery.fixedTblHdrLftCol.js
@@ -29,7 +29,9 @@
         wrapper: {
           outer: {
             idName: null,
-            className: 'fTHLC-outer-wrapper'
+            className: 'fTHLC-outer-wrapper',
+            width : null,
+            height: null
           },
           inner: {
             idName: null,
@@ -54,21 +56,33 @@
       var scrollHeight = cfg.scroll.height;
       var fixedLeftWidth = null;
       var fixedHeadHeight = null;
+      var wrapperOuterWidth = cfg.wrapper.outer.width;
+      var wrapperOuterHeight = cfg.wrapper.outer.height;
 
       function getScrollWidth(table) {
         var width = scrollWidth;
-        
-        if(!width)
-          width = table.outerWidth(true) - getFixedLeftWidth(table);
-        
+
+        if(!width){
+          if( wrapperOuterWidth ){
+            width = wrapperOuterWidth;
+          }else{
+            width = table.outerWidth(true) - getFixedLeftWidth(table);
+          }
+        }
+
         return width;
       }
       
       function getScrollHeight(table) {
         var height = scrollHeight;
-        
-        if(!height)
-          height = table.outerHeight(true) - getFixedHeadHeight(table);
+
+        if(!height){
+          if( wrapperOuterHeight ){
+            height = wrapperOuterHeight;
+          }else{
+            height = table.outerHeight(true) - getFixedHeadHeight(table);
+          }
+        }
         
         return height;
       }
@@ -145,7 +159,6 @@
 
           fixedLeftWidth = width;
         }
-
         return width;
       }
       
@@ -164,8 +177,8 @@
           .wrap($(document.createElement('div'))
           .attr('id', cfg.wrapper.outer.idName)
           .addClass(cfg.wrapper.outer.className)
-          .css('width', getScrollWidth(table))
-          .css('height', getScrollHeight(table))
+          .css('width', cfg.wrapper.outer.width != null ? cfg.wrapper.outer.width : getScrollWidth(table))
+          .css('height', cfg.wrapper.outer.height != null? cfg.wrapper.outer.height : getScrollHeight(table))
           .css('position', 'relative')
           .css('padding-left', getFixedLeftWidth(table)+'px')
           .css('padding-top', getFixedHeadHeight(table)+'px')

--- a/samples/sample_4_setWrapperOuter.html
+++ b/samples/sample_4_setWrapperOuter.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Sample - Basic</title>
+    <link rel="stylesheet" href="http://yui.yahooapis.com/3.17.2/build/cssreset/cssreset-min.css">
+    <link rel="stylesheet" href="sample.css" />
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="../jquery.fixedTblHdrLftCol.js"></script>
+    <script>
+      $(function() {
+        $('table').fixedTblHdrLftCol({
+          wrapper:{
+            outer:{
+              height: 550,
+              width: 600
+            }
+          }
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <table>
+      <thead>
+        <tr>
+          <th>Sample</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th><th>9</th><th>10</th><th>11</th><th>12</th><th>13</th><th>14</th><th>15</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td><td>1-1</td><td>1-2</td><td>1-3</td><td>1-4</td><td>1-5</td><td>1-6</td><td>1-7</td><td>1-8</td><td>1-9</td><td>1-10</td><td>1-11</td><td>1-12</td><td>1-13</td><td>1-14</td><td>1-15</td>
+        </tr>
+        <tr>
+          <td>2</td><td>2-1</td><td>2-2</td><td>2-3</td><td>2-4</td><td>2-5</td><td>2-6</td><td>2-7</td><td>2-8</td><td>2-9</td><td>2-10</td><td>2-11</td><td>2-12</td><td>2-13</td><td>2-14</td><td>2-15</td>
+        </tr>
+        <tr>
+          <td>3</td><td>3-1</td><td>3-2</td><td>3-3</td><td>3-4</td><td>3-5</td><td>3-6</td><td>3-7</td><td>3-8</td><td>3-9</td><td>3-10</td><td>3-11</td><td>3-12</td><td>3-13</td><td>3-14</td><td>3-15</td>
+        </tr>
+        <tr>
+          <td>4</td><td>4-1</td><td>4-2</td><td>4-3</td><td>4-4</td><td>4-5</td><td>4-6</td><td>4-7</td><td>4-8</td><td>4-9</td><td>4-10</td><td>4-11</td><td>4-12</td><td>4-13</td><td>4-14</td><td>4-15</td>
+        </tr>
+        <tr>
+          <td>5</td><td>5-1</td><td>5-2</td><td>5-3</td><td>5-4</td><td>5-5</td><td>5-6</td><td>5-7</td><td>5-8</td><td>5-9</td><td>5-10</td><td>5-11</td><td>5-12</td><td>5-13</td><td>5-14</td><td>5-15</td>
+        </tr>
+        <tr>
+          <td>6</td><td>6-1</td><td>6-2</td><td>6-3</td><td>6-4</td><td>6-5</td><td>6-6</td><td>6-7</td><td>6-8</td><td>6-9</td><td>6-10</td><td>6-11</td><td>6-12</td><td>6-13</td><td>6-14</td><td>6-15</td>
+        </tr>
+        <tr>
+          <td>7</td><td>7-1</td><td>7-2</td><td>7-3</td><td>7-4</td><td>7-5</td><td>7-6</td><td>7-7</td><td>7-8</td><td>7-9</td><td>7-10</td><td>7-11</td><td>7-12</td><td>7-13</td><td>7-14</td><td>7-15</td>
+        </tr>
+        <tr>
+          <td>8</td><td>8-1</td><td>8-2</td><td>8-3</td><td>8-4</td><td>8-5</td><td>8-6</td><td>8-7</td><td>8-8</td><td>8-9</td><td>8-10</td><td>8-11</td><td>8-12</td><td>8-13</td><td>8-14</td><td>8-15</td>
+        </tr>
+        <tr>
+          <td>9</td><td>9-1</td><td>9-2</td><td>9-3</td><td>9-4</td><td>9-5</td><td>9-6</td><td>9-7</td><td>9-8</td><td>9-9</td><td>9-10</td><td>9-11</td><td>9-12</td><td>9-13</td><td>9-14</td><td>9-15</td>
+        </tr>
+        <tr>
+          <td>10</td><td>10-1</td><td>10-2</td><td>10-3</td><td>10-4</td><td>10-5</td><td>10-6</td><td>10-7</td><td>10-8</td><td>10-9</td><td>10-10</td><td>10-11</td><td>10-12</td><td>10-13</td><td>10-14</td><td>10-15</td>
+        </tr>
+        <tr>
+          <td>11</td><td>11-1</td><td>11-2</td><td>11-3</td><td>11-4</td><td>11-5</td><td>11-6</td><td>11-7</td><td>11-8</td><td>11-9</td><td>11-10</td><td>11-11</td><td>11-12</td><td>11-13</td><td>11-14</td><td>11-15</td>
+        </tr>
+        <tr>
+          <td>12</td><td>12-1</td><td>12-2</td><td>12-3</td><td>12-4</td><td>12-5</td><td>12-6</td><td>12-7</td><td>12-8</td><td>12-9</td><td>12-10</td><td>12-11</td><td>12-12</td><td>12-13</td><td>12-14</td><td>12-15</td>
+        </tr>
+        <tr>
+          <td>13</td><td>13-1</td><td>13-2</td><td>13-3</td><td>13-4</td><td>13-5</td><td>13-6</td><td>13-7</td><td>13-8</td><td>13-9</td><td>13-10</td><td>13-11</td><td>13-12</td><td>13-13</td><td>13-14</td><td>13-15</td>
+        </tr>
+        <tr>
+          <td>14</td><td>14-1</td><td>14-2</td><td>14-3</td><td>14-4</td><td>14-5</td><td>14-6</td><td>14-7</td><td>14-8</td><td>14-9</td><td>14-10</td><td>14-11</td><td>14-12</td><td>14-13</td><td>14-14</td><td>14-15</td>
+        </tr>
+        <tr>
+          <td>15</td><td>15-1</td><td>15-2</td><td>15-3</td><td>15-4</td><td>15-5</td><td>15-6</td><td>15-7</td><td>15-8</td><td>15-9</td><td>15-10</td><td>15-11</td><td>15-12</td><td>15-13</td><td>15-14</td><td>15-15</td>
+        </tr>
+        <tr>
+          <td>16</td><td>16-1</td><td>16-2</td><td>16-3</td><td>16-4</td><td>16-5</td><td>16-6</td><td>16-7</td><td>16-8</td><td>16-9</td><td>16-10</td><td>16-11</td><td>16-12</td><td>16-13</td><td>16-14</td><td>16-15</td>
+        </tr>
+        <tr>
+          <td>17</td><td>17-1</td><td>17-2</td><td>17-3</td><td>17-4</td><td>17-5</td><td>17-6</td><td>17-7</td><td>17-8</td><td>17-9</td><td>17-10</td><td>17-11</td><td>17-12</td><td>17-13</td><td>17-14</td><td>17-15</td>
+        </tr>
+        <tr>
+          <td>18</td><td>18-1</td><td>18-2</td><td>18-3</td><td>18-4</td><td>18-5</td><td>18-6</td><td>18-7</td><td>18-8</td><td>18-9</td><td>18-10</td><td>18-11</td><td>18-12</td><td>18-13</td><td>18-14</td><td>18-15</td>
+        </tr>
+        <tr>
+          <td>19</td><td>19-1</td><td>19-2</td><td>19-3</td><td>19-4</td><td>19-5</td><td>19-6</td><td>19-7</td><td>19-8</td><td>19-9</td><td>19-10</td><td>19-11</td><td>19-12</td><td>19-13</td><td>19-14</td><td>19-15</td>
+        </tr>
+        <tr>
+          <td>20</td><td>20-1</td><td>20-2</td><td>20-3</td><td>20-4</td><td>20-5</td><td>20-6</td><td>20-7</td><td>20-8</td><td>20-9</td><td>20-10</td><td>20-11</td><td>20-12</td><td>20-13</td><td>20-14</td><td>20-15</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Hi, with this small changes you can set the width and height of div wrapper outer. 

example:

``` javascript
$("table").fixedTblHdrLftCol({
          wrapper:{
            outer:{
              height: 550,
              width: 600
            }
          }
        }); 
```

And the div with class **_fTHLC-outer-wrapper**_ set this values for personal view
